### PR TITLE
[Fix #1] Ensure forks don't attempt deploy in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,14 @@ jdk:
 stages:
   - name: test
   - name: check
+  # Deploy only from the home repo where the credentials can be
+  # properly decrypted. Never deploy from a pull request job.
+  # In addition, ensure we're on the master branch (snapshots)
+  # or a tagged version (releases).
   - name: deploy
-    if: ( branch = master ) OR ( tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ )
+    if: repo = gonewest818/lein-sysutils
+        AND type != pull_request
+        AND ( branch = master OR branch =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ )
 jobs:
   include:
     # Test Clojure master against a single JDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file. This change
 
 ## Unreleased
 ### Changed
-- none
+- [#1] Ensure CI jobs running in forks don't attempt to deploy to our Clojars account.
 
 ## 0.2.0
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -30,19 +30,10 @@ release:
 
 # Deploying requires the caller to set environment variables as
 # specified in project.clj to provide a login and password to the
-# artifact repository.  We're setting TRAVIS_PULL_REQUEST to a default
-# value to avoid accidentally deploying from the command line. Inside
-# Travis CI this variable will be set to the pull request number, or
-# to "false" if it's not a pull request.
-
-TRAVIS_PULL_REQUEST ?= "true"
+# artifact repository.
 
 deploy:
-	if [ "$(TRAVIS_PULL_REQUEST)" != "false" ]; then \
-	    echo "Pull request detected. Skipping deploy."; \
-	else \
-	    lein with-profile +$(VERSION) deploy clojars; \
-	fi
+	lein with-profile +$(VERSION) deploy clojars;
 
 clean:
 	lein clean


### PR DESCRIPTION
In this commit we're consolidating all of the logic that determines
when to run the deploy job into `.travis.yml` for clarity. We now
permit the deploy stage to run only if:

  - repo is "gonewest818/lein-sysutils"
  - job type is not a pull request
  - branch is "master" or named "v#.#.#" consistent with a release

The purpose of this logic is to avoid attempting deploys to our
project Clojars account except when it is valid to do so.
