### PR TITLE
Extend for Java 10 - 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,11 @@ env:
 jdk:
   - openjdk7
   - openjdk8
+  - openjdk11
   - oraclejdk8
   - oraclejdk9
+  - oraclejdk10
+  - oraclejdk11
 stages:
   - name: test
   - name: check

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,11 @@ env:
 jdk:
   - openjdk7
   - openjdk8
+  - openjdk9
+  - openjdk10
   - openjdk11
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk10
   - oraclejdk11
 stages:
   - name: test

--- a/src/leiningen/sysutils.clj
+++ b/src/leiningen/sysutils.clj
@@ -71,7 +71,7 @@
         values (map sysutils-lookup names)]
     (-> (zipmap keys values)
         (add-java-versions)
-        (assoc-java-version-simple ))))
+        (assoc-java-version-simple))))
 
 (defn format-output
   "Print the map m. If the edn parameter is false then print exactly one

--- a/test/leiningen/sysutils_test.clj
+++ b/test/leiningen/sysutils_test.clj
@@ -8,6 +8,21 @@
   (let [m (assoc-java-version-simple {:is-java-1-1 true})]
     (is (= "1.1" (:java-version-simple m)) "known java version")))
 
+(deftest add-java-versions-test
+  (let [m (add-java-versions {:java-specification-version "11"})]
+    (is (false? (:is-java-10 m)))
+    (is (true? (:is-java-11 m)))
+    (is (false? (:is-java-12 m))))
+  (let [m (add-java-versions {:is-java-10 false
+                              :is-java-12 true})]
+    (is (false? (:is-java-10 m))
+        (true? (:is-java-12 m)))))
+
+(deftest extend-is-java-x-test
+  (let [m (sysutils-map)]
+    (is (= (:java-specification-version m)
+           (:java-version-simple m)))))
+
 (deftest keywordize-test
   (is (= :simple      (keywordize "SIMPLE")))
   (is (= :two-words   (keywordize "TWO_WORDS")))

--- a/test/leiningen/sysutils_test.clj
+++ b/test/leiningen/sysutils_test.clj
@@ -15,8 +15,8 @@
     (is (false? (:is-java-12 m))))
   (let [m (add-java-versions {:is-java-10 false
                               :is-java-12 true})]
-    (is (false? (:is-java-10 m))
-        (true? (:is-java-12 m)))))
+    (is (false? (:is-java-10 m)))
+    (is (true? (:is-java-12 m)))))
 
 (deftest extend-is-java-x-test
   (let [m (sysutils-map)]


### PR DESCRIPTION
I thought this would be more straight forward, but:

- `IS_JAVA_XX` are hard coded into SystemUtils. The latest version (3.7?) includes `IS_JAVA_10` and `IS_JAVA_11`, but no further. I'm sure `IS_JAVA_12` will be added soon, but doesn't look like they'll pre-empty future versions. 
-  We get our version of `common-lang3` via `leiningen-core`, which is around 3.5 at the moment for lein 2.9.1, which only has `IS_JAVA_9`.

This PR replicates the internal logic of SystemUtils to patch this. We can speculatively add more versions, of course. But...

I suspect `:java-simple-version` is just a very roundabout way to reproduce `:java-specification-version` that's already there, except guaranteed to not produce `:java-unknown`. e.g.:

```
 > lein sysutils :java-specification-version
:java-specification-version 11
```
so an alternative is to just deprecate the `java-simple-version` key and point people towards the built in `:java-specification-version` key? 